### PR TITLE
remove an unneeded include

### DIFF
--- a/include/cyclone/ck_ht_hash.h
+++ b/include/cyclone/ck_ht_hash.h
@@ -32,7 +32,6 @@
  */
 
 #include <ck_stdint.h>
-#include <ck_string.h>
 
 //-----------------------------------------------------------------------------
 // MurmurHash3 was written by Austin Appleby, and is placed in the public


### PR DESCRIPTION
On my Ubuntu 16.04.1 computer apt provided libck 0.4.4, which doesn't come with ck_string.h.  ck_ht_hash.h appears to compile without the include.