### PR TITLE
Build support for MSYS2 on Windows

### DIFF
--- a/Makefile.config.msys2
+++ b/Makefile.config.msys2
@@ -1,0 +1,84 @@
+# Cyclone Scheme
+# Copyright (c) 2014, Justin Ethier
+# All rights reserved.
+#
+# Configuration options for the makefile
+
+# Compiler options
+CFLAGS       ?= -O2 -fPIC -rdynamic -Wall -Iinclude -L. -I$(INSTALL_DIR)/usr/local/include -L$(INSTALL_DIR)/usr/local/lib
+COMP_CFLAGS  ?= -O2 -fPIC -rdynamic -Wall -I$(PREFIX)/include -L$(PREFIX)/lib
+# Use these lines instead for debugging or profiling
+#CFLAGS = -g -Wall
+#CFLAGS = -g -pg -Wall
+CC      ?= cc
+LIBS = -pthread -lcyclone -lck -lm -ltommath -ldl
+
+# Commands "baked into" cyclone for invoking the C compiler
+CC_PROG ?= "$(CC) ~src-file~ $(COMP_CFLAGS) -c -o ~exec-file~.o"
+CC_EXEC ?= "$(CC) ~exec-file~.o ~obj-files~ $(LIBS) $(COMP_CFLAGS) -o ~exec-file~"
+CC_LIB  ?= "$(CC) ~src-file~ $(COMP_CFLAGS) -c -o ~exec-file~.o"
+CC_SO   ?= "$(CC) -shared -rdynamic -o ~exec-file~.so ~exec-file~.o"
+
+AR        ?= ar
+#CD        ?= cd
+RM        ?= rm -f
+#LS        ?= ls
+#CP        ?= cp
+#LN        ?= ln
+INSTALL   ?= install
+MKDIR     ?= $(INSTALL) -d
+RMDIR     ?= rmdir
+
+PREFIX    ?= /usr/local
+BINDIR    ?= $(PREFIX)/bin
+LIBDIR    ?= $(PREFIX)/lib
+INCDIR    ?= $(PREFIX)/include/cyclone
+DATADIR   ?= $(PREFIX)/share/cyclone
+
+DESTDIR   ?=
+
+# Automatically detect platform-specific flags, instead of using autoconf
+#CYC_PLATFORM_HAS_MEMSTREAM ?= 1
+CYC_PLATFORM_HAS_MEMSTREAM := $(shell echo "main(){char *buf; int len; open_memstream(&buf, &len);}" | gcc -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
+CYC_PLATFORM_HAS_FMEMOPEN := $(shell echo "main(){char *buf; fmemopen(&buf, 0, \"r\");}" | gcc -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
+
+# code from chibi's makefile to detect platform
+ifndef PLATFORM
+ifeq ($(shell uname),Darwin)
+PLATFORM=macosx
+else
+ifeq ($(shell uname),FreeBSD)
+PLATFORM=bsd
+else
+ifeq ($(shell uname),NetBSD)
+PLATFORM=bsd
+else
+ifeq ($(shell uname),OpenBSD)
+PLATFORM=bsd
+else
+ifeq ($(shell uname),DragonFly)
+PLATFORM=bsd
+else
+ifeq ($(shell uname -o),Msys)
+PLATFORM=mingw
+SOLIBDIR = $(BINDIR)
+DIFFOPTS = -b
+else
+ifeq ($(shell uname -o),Cygwin)
+PLATFORM=cygwin
+SOLIBDIR = $(BINDIR)
+DIFFOPTS = -b
+else
+ifeq ($(shell uname -o),GNU/Linux)
+PLATFORM=linux
+else
+PLATFORM=unix
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif
+endif

--- a/README.Windows.md
+++ b/README.Windows.md
@@ -1,0 +1,30 @@
+Instructions for building on Windows using MSYS
+-----------------------------------------------
+
+
+1. Download msys2 from http://www.msys2.org/
+2. Install msys2 to a location of your choice - say C:\msys64 (the steps should work for 32bit too)
+3. Run C:\msys64\msys2.exe
+4. Run "pacman -Syu" (Hit 'Y' when asked - Proceed with installation?). Just close the terminal window if you get the warning about "terminating msys2 without returning to shell" - there is a known issue[https://github.com/StephanTLavavej/mingw-distro/issues/20] with msys.
+5. Run C:\msys64\msys2.exe and execute the following commands in the msys terminal
+6. pacman -Su (Hit 'Y' when asked - Proceed with installation?)
+7. pacman -S gcc make autoconf git (Hit 'Y' when asked - Proceed with installation?)
+8. 
+
+
+
+
+
+git clone https://github.com/justinethier/cyclone-bootstrap.git
+
+git clone https://github.com/libtom/libtommath.git
+
+make
+DESTDIR=/home/ckk/Cyclone/install make install
+
+
+git clone https://github.com/concurrencykit/ck.git
+./configure
+make
+DESTDIR=/home/ckk/Cyclone/install make install
+

--- a/README.Windows.md
+++ b/README.Windows.md
@@ -13,29 +13,9 @@ Instructions for building on Windows using MSYS
 2. pacman -Su (Hit 'Y' when asked - Proceed with installation?)
 3. pacman -S gcc make autoconf git (Hit 'Y' when asked - Proceed with installation?)
 
-### Create a directory to contain everthing needed for cyclone-bootstrap
-1. export CYCLONE=$PWD/CYCLONE
-2. mkdir $CYCLONE
-3. cd $CYCLONE
-4. mkdir $CYCLONE/install
+### Build and install cyclone-bootstrap
+1. git clone https://github.com/justinethier/cyclone-bootstrap.git
+2. cd cyclone-bootstrap
+3. ./setup.mysys.sh - this will fetch and build all the dependencies.
 
-### Build and install libtomath
-1. git clone https://github.com/libtom/libtommath.git
-2. 
-
-
-
-
-git clone https://github.com/justinethier/cyclone-bootstrap.git
-
-git clone https://github.com/libtom/libtommath.git
-
-make
-DESTDIR=/home/ckk/Cyclone/install make install
-
-
-git clone https://github.com/concurrencykit/ck.git
-./configure
-make
-DESTDIR=/home/ckk/Cyclone/install make install
-
+You will have cyclone.exe and icyc.exe generated at $(HOME)/CYCLONE_ROOT/INSTALL/usr/local/bin!

--- a/README.Windows.md
+++ b/README.Windows.md
@@ -1,7 +1,6 @@
 Instructions for building on Windows using MSYS
 -----------------------------------------------
 
-
 ### Install MSYS2
 1. Download msys2 from http://www.msys2.org/
 2. Install msys2 to a location of your choice - say C:\msys64 (the steps should work for 32bit too)

--- a/README.Windows.md
+++ b/README.Windows.md
@@ -2,15 +2,26 @@ Instructions for building on Windows using MSYS
 -----------------------------------------------
 
 
+### Install MSYS2
 1. Download msys2 from http://www.msys2.org/
 2. Install msys2 to a location of your choice - say C:\msys64 (the steps should work for 32bit too)
 3. Run C:\msys64\msys2.exe
 4. Run "pacman -Syu" (Hit 'Y' when asked - Proceed with installation?). Just close the terminal window if you get the warning about "terminating msys2 without returning to shell" - there is a known issue[https://github.com/StephanTLavavej/mingw-distro/issues/20] with msys.
-5. Run C:\msys64\msys2.exe and execute the following commands in the msys terminal
-6. pacman -Su (Hit 'Y' when asked - Proceed with installation?)
-7. pacman -S gcc make autoconf git (Hit 'Y' when asked - Proceed with installation?)
-8. 
 
+### Install necessary tools in MSYS2
+1. Run C:\msys64\msys2.exe and execute the following commands in the msys terminal
+2. pacman -Su (Hit 'Y' when asked - Proceed with installation?)
+3. pacman -S gcc make autoconf git (Hit 'Y' when asked - Proceed with installation?)
+
+### Create a directory to contain everthing needed for cyclone-bootstrap
+1. export CYCLONE=$PWD/CYCLONE
+2. mkdir $CYCLONE
+3. cd $CYCLONE
+4. mkdir $CYCLONE/install
+
+### Build and install libtomath
+1. git clone https://github.com/libtom/libtommath.git
+2. 
 
 
 

--- a/setup.mysys.sh
+++ b/setup.mysys.sh
@@ -42,4 +42,4 @@ cp -v Makefile.config.msys2 Makefile.config
 # Fixing up the Makefile - this is a temporary crude workaround
 perl -pi -e 's/-shared -rdynamic/-Wl,-undefined -shared -rdynamic/' Makefile
 make
-DESTDIR=$INSTALL_DIR$INSTALL_RELATIVE make install
+DESTDIR=$INSTALL_DIR make install

--- a/setup.mysys.sh
+++ b/setup.mysys.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+
+CYCLONE_BOOTSTRAP_SRC=$PWD
+
+# Root directory where everthing related
+# to cyclone-bootstrap will reside.
+export CYCLONE_ROOT=$HOME/CYCLONE_ROOT
+export INSTALL_DIR=$CYCLONE_ROOT/INSTALL
+export INSTALL_RELATIVE=/usr/local
+
+
+# Create the necessary directories
+mkdir $CYCLONE_ROOT $INSTALL_DIR
+
+# Build and install libtommath
+cd $CYCLONE_ROOT
+repo=https://github.com/libtom/libtommath.git 
+echo "Cloning $repo"
+git clone $repo
+cd libtommath
+LIBPATH=$INSTALL_RELATIVE/lib INCPATH=$INSTALL_RELATIVE/include make
+LIBPATH=$INSTALL_RELATIVE/lib INCPATH=$INSTALL_RELATIVE/include DESTDIR=$INSTALL_DIR make install
+
+
+# Build and install concurrencykit
+cd $CYCLONE_ROOT
+repo=https://github.com/concurrencykit/ck.git
+echo "Cloning $repo"
+git clone $repo
+cd ck
+./configure
+make
+DESTDIR=$INSTALL_DIR make install
+
+
+# Get back to cyclone-bootstrap
+cd $CYCLONE_BOOTSTRAP_SRC
+cp -v Makefile.config.msys2 Makefile.config
+
+
+# Fixing up the Makefile - this is a temporary crude workaround
+perl -pi -e 's/-shared -rdynamic/-Wl,-undefined -shared -rdynamic/' Makefile
+make
+DESTDIR=$INSTALL_DIR$INSTALL_RELATIVE make install


### PR DESCRIPTION
This change contains a README for instructions to build on Windows. Instructions are mostly to install MSYS2 itself, the actual installation is done by the shell script that fetches and builds libtommath and concurrencykit and then builds and installs cyclone-bootstrap.