### PR TITLE
Fix msys2 build script to accommodate the change to libtommath build and add build script for mac

### DIFF
--- a/README.Mac.md
+++ b/README.Mac.md
@@ -1,7 +1,7 @@
-Instructions for building on Mac using gcc-6
---------------------------------------------
+Instructions for building on Mac 
+--------------------------------
 
-### Install Homebrew and gcc
+### Install Homebrew and gcc (You can skip this if you already have gcc from XCode)
 1. Please follow the instructions at https://brew.sh/ to install homebrew
 2. brew install gcc
 3. Install git from https://git-scm.com/

--- a/README.Mac.md
+++ b/README.Mac.md
@@ -1,0 +1,15 @@
+Instructions for building on Mac using gcc-6
+--------------------------------------------
+
+### Install Homebrew and gcc
+1. Please follow the instructions at https://brew.sh/ to install homebrew
+2. brew install gcc
+3. Install git from https://git-scm.com/
+
+### Build and install cyclone-bootstrap
+1. git clone https://github.com/justinethier/cyclone-bootstrap.git
+2. cd cyclone-bootstrap
+3. ./setup.mac.sh - this will fetch and build all the dependencies.
+
+You will have cyclone.exe and icyc.exe generated at $(HOME)/CYCLONE_ROOT/INSTALL/usr/local/bin!
+Please set library path by doing export DYLD_LIBRARY_PATH=$HOME/CYCLONE_ROOT/INSTALL/usr/local/lib

--- a/setup.mac.sh
+++ b/setup.mac.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+
+CYCLONE_BOOTSTRAP_SRC=$PWD
+
+# Root directory where everthing related
+# to cyclone-bootstrap will reside.
+export CYCLONE_ROOT=$HOME/CYCLONE_ROOT
+export INSTALL_DIR=$CYCLONE_ROOT/INSTALL
+export INSTALL_RELATIVE=/usr/local
+
+
+# Create the necessary directories
+mkdir $CYCLONE_ROOT $INSTALL_DIR
+
+# Build and install libtommath
+cd $CYCLONE_ROOT
+repo=https://github.com/libtom/libtommath.git 
+echo "Cloning $repo"
+git clone $repo
+cd libtommath
+LIBPATH=$INSTALL_DIR/$INSTALL_RELATIVE/lib INCPATH=$INSTALL_DIR/$INSTALL_RELATIVE/include make
+LIBPATH=$INSTALL_DIR/$INSTALL_RELATIVE/lib INCPATH=$INSTALL_DIR/$INSTALL_RELATIVE/include make install
+
+
+# Build and install concurrencykit
+cd $CYCLONE_ROOT
+repo=https://github.com/concurrencykit/ck.git
+echo "Cloning $repo"
+git clone $repo
+cd ck
+./configure
+make
+DESTDIR=$INSTALL_DIR make install
+
+
+# Get back to cyclone-bootstrap
+cd $CYCLONE_BOOTSTRAP_SRC
+cp -v Makefile.config.msys2 Makefile.config
+
+
+# Fixing up the Makefile - this is a temporary crude workaround
+perl -pi -e 's/-shared -rdynamic/-Wl,-undefined -Wl,dynamic_lookup -shared -rdynamic/' Makefile
+make
+DESTDIR=$INSTALL_DIR make install

--- a/setup.mysys.sh
+++ b/setup.mysys.sh
@@ -19,8 +19,8 @@ repo=https://github.com/libtom/libtommath.git
 echo "Cloning $repo"
 git clone $repo
 cd libtommath
-LIBPATH=$INSTALL_RELATIVE/lib INCPATH=$INSTALL_RELATIVE/include make
-LIBPATH=$INSTALL_RELATIVE/lib INCPATH=$INSTALL_RELATIVE/include DESTDIR=$INSTALL_DIR make install
+LIBPATH=$INSTALL_DIR/$INSTALL_RELATIVE/lib INCPATH=$INSTALL_DIR/$INSTALL_RELATIVE/include make
+LIBPATH=$INSTALL_DIR/$INSTALL_RELATIVE/lib INCPATH=$INSTALL_DIR/$INSTALL_RELATIVE/include make install
 
 
 # Build and install concurrencykit


### PR DESCRIPTION
- Fixed setup.msys2.sh to not use DESTDIR during libtommath build since libtommath does not use it anymore.
- Add build script and a corresponding readme for mac.
