### PR TITLE
Fixes for building on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ C_SHARED_OBJECTS=$(CFILES:.c=.so)
 	$(CC) $(CFLAGS) $< -c -o $@
 
 %.so: %.o
-	$(CC) -shared -rdynamic -o $@ $<
+	$(CC) -shared $(LDFLAGS) -o $@ $<
 
 all: cyclone icyc-c
 
@@ -40,19 +40,19 @@ libcyclone.a: runtime.c include/cyclone/runtime.h gc.c dispatch.c mstreams.c
 
 cyclone: $(CFILES) $(COBJECTS) $(C_SHARED_OBJECTS) libcyclone.a
 	$(CC) cyclone.c $(CFLAGS) -c -o cyclone.o
-	$(CC) cyclone.o $(COBJECTS) $(LIBS) $(CFLAGS) -o cyclone
+	$(CC) cyclone.o $(COBJECTS) $(LIBS) $(LDFLAGS) -o cyclone
 
 .PHONY: icyc-c
 icyc-c: $(CFILES) $(COBJECTS) $(C_SHARED_OBJECTS) libcyclone.a
 	$(CC) icyc.c $(CFLAGS) -c -o icyc.o
-	$(CC) icyc.o $(COBJECTS) $(LIBS) $(CFLAGS) -o icyc
+	$(CC) icyc.o $(COBJECTS) $(LIBS) $(LDFLAGS) -o icyc
 
 icyc: cyclone
 	./cyclone icyc.scm
 
 .PHONY: test
 test:
-	make unit-tests
+	$(MAKE) unit-tests
 
 unit-tests: unit-tests.scm
 	./cyclone unit-tests.scm && ./unit-tests

--- a/Makefile.config
+++ b/Makefile.config
@@ -4,14 +4,32 @@
 #
 # Configuration options for the makefile
 
+OS ?= $(shell uname)
+CC ?= cc
+
+LIBS = -pthread -lcyclone -lck -lm -ltommath
+ifneq ($(OS),FreeBSD)
+# libdl is part of libc on FreeBSD
+LIBS += -ldl
+endif
+
 # Compiler options
-CFLAGS       ?= -O2 -fPIC -rdynamic -Wall -Iinclude -L.
-COMP_CFLAGS  ?= -O2 -fPIC -rdynamic -Wall -I$(PREFIX)/include -L$(PREFIX)/lib
+CFLAGS       ?= -O2 -fPIC -Wall -Iinclude
+COMP_CFLAGS  ?= -O2 -fPIC -Wall -I$(PREFIX)/include -L$(PREFIX)/lib -Wl,--export-dynamic
 # Use these lines instead for debugging or profiling
 #CFLAGS = -g -Wall
 #CFLAGS = -g -pg -Wall
-CC      ?= cc
-LIBS = -pthread -lcyclone -lck -lm -ltommath -ldl
+
+# Linker options
+LDFLAGS ?= -Wl,--export-dynamic -L.
+
+# /usr/local is not in the search path by default on FreeBSD, so if libtommath and/or
+# concurrencykit was installed via Ports, it won't be picked up without explicitly looking
+# for it here
+ifeq ($(OS),FreeBSD)
+LDFLAGS += -L/usr/local/lib
+CFLAGS  += -I/usr/local/include
+endif
 
 # Commands "baked into" cyclone for invoking the C compiler
 CC_PROG ?= "$(CC) ~src-file~ $(COMP_CFLAGS) -c -o ~exec-file~.o"
@@ -44,41 +62,21 @@ CYC_PLATFORM_HAS_FMEMOPEN := $(shell echo "main(){char *buf; fmemopen(&buf, 0, \
 
 # code from chibi's makefile to detect platform
 ifndef PLATFORM
-ifeq ($(shell uname),Darwin)
+ifeq ($(OS),Darwin)
 PLATFORM=macosx
-else
-ifeq ($(shell uname),FreeBSD)
+else ifneq (,$(findstring $(OS),FreeBSD NetBSD OpenBSD DragonFly))
 PLATFORM=bsd
-else
-ifeq ($(shell uname),NetBSD)
-PLATFORM=bsd
-else
-ifeq ($(shell uname),OpenBSD)
-PLATFORM=bsd
-else
-ifeq ($(shell uname),DragonFly)
-PLATFORM=bsd
-else
-ifeq ($(shell uname -o),Msys)
+else ifeq ($(shell uname -o),Msys)
 PLATFORM=mingw
 SOLIBDIR = $(BINDIR)
 DIFFOPTS = -b
-else
-ifeq ($(shell uname -o),Cygwin)
+else ifeq ($(shell uname -o),Cygwin)
 PLATFORM=cygwin
 SOLIBDIR = $(BINDIR)
 DIFFOPTS = -b
-else
-ifeq ($(shell uname -o),GNU/Linux)
+else ifeq ($(shell uname -o),GNU/Linux)
 PLATFORM=linux
 else
 PLATFORM=unix
-endif
-endif
-endif
-endif
-endif
-endif
-endif
 endif
 endif


### PR DESCRIPTION
Like macOS, FreeBSD uses Clang as its default compiler. Some of the changes here apply to any platform using Clang, but most are for FreeBSD in particular. All changes made in this PR are pretty minor.