### PR TITLE
updated Mac install instructions for new homebrew-cyclone repo location in cyclone-scheme org

### DIFF
--- a/README.Mac.md
+++ b/README.Mac.md
@@ -8,8 +8,8 @@ and then use it to compile cyclone from source and install that.
 
 1. Follow the instructions at https://brew.sh/ to install the homebrew package manager.
 2. Run the following commands:
-  - brew tap adamfeuer/cyclone
-  - brew install adamfeuer/cyclone/cyclone
+  - brew tap cyclone-scheme/cyclone
+  - brew install cyclone-scheme/cyclone/cyclone
 
 
 ### Compiling from source


### PR DESCRIPTION
## Summary

- updated Mac install instructions for new homebrew-cyclone repo location in cyclone-scheme org