### PR TITLE
Makefile: Allow running `make test` before `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ TESTS = $(basename $(TEST_SRC))
 test: $(TESTS)
 
 $(TESTS) : %: %.scm
-	./cyclone -I . $<
+	./cyclone -I libs -COPT '-Iinclude' -CLNK '-L.' $<
 	./$@
 	rm -rf $@ $@.c $@.o
 


### PR DESCRIPTION
I am currently working on a cyclone package for the [Alpine Linux](https://alpinelinux.org) Linux distribution. As part of the package recipe, we also try to execute the upstream test suite (if available) to ensure the packaged software works on all of our supported architectures. At Alpine, our test stage is run before the install stage (in my experience other Linux distros usually do the same). Unfortunately, the cyclone-bootstrap test target seems to assume that `make install` was run prior to `make test` which initially prevented me from enabling the test suite in our Alpine package recipe.

However, by telling cyclone that it should search for libraries and headers in the current directory I was able to make the test suite passes even without running `make install`. I figured you might be interested in this change and therefore decided to propose it as a PR. If you are not interested just close this and I will only apply the patch for the Alpine package.

<!--
BTW: The same thing also seems to apply to the non-bootstrap version of cyclone. For instance, the [Development Guide](https://github.com/justinethier/cyclone/blob/master/docs/Development.md#testing-a-build) recommends installing first before running the test suite as the test suite will also just use the installed libraries by default. I was personally briefly confused by this when working on https://github.com/justinethier/cyclone/pull/473. Maybe it makes sense to also use the flags proposed here in the `CYCLONE` variable in the `Makefile` of the non-bootstrap cyclone version?

Let me know what you think.-->